### PR TITLE
Enable chassisd on all platforms (limited)

### DIFF
--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -28,9 +28,13 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 
-{% if not skip_chassisd and IS_MODULAR_CHASSIS == 1 %}
+{% if not skip_chassisd %}
 [program:chassisd]
+{% if IS_MODULAR_CHASSIS == 1 %}
 command=/usr/local/bin/chassisd
+{% else %}
+command=/usr/local/bin/chassisd --init-only
+{% endif %}
 priority=3
 autostart=false
 autorestart=false

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -28,13 +28,9 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 
-{% if not skip_chassisd %}
+{% if not skip_chassisd and IS_MODULAR_CHASSIS == 1 %}
 [program:chassisd]
-{% if IS_MODULAR_CHASSIS == 1 %}
 command=/usr/local/bin/chassisd
-{% else %}
-command=/usr/local/bin/chassisd --init-only
-{% endif %}
 priority=3
 autostart=false
 autorestart=false

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -41,7 +41,7 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}
 
-[program:chassisd]
+[program:chassisshow]
 command=/usr/local/bin/chassisshow
 priority=3
 autostart=false

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -41,6 +41,17 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}
 
+[program:chassisd]
+command=/usr/local/bin/chassisshow
+priority=3
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+startsecs=0
+dependent_startup=true
+dependent_startup_wait_for=rsyslogd:running
+
 {% if not skip_sensors and HAVE_SENSORS_CONF == 1 %}
 [program:lm-sensors]
 command=/usr/bin/lm-sensors.sh


### PR DESCRIPTION
Proposal for chassisd revision to allow synchronizing basic platform information to STATE_DB on all platforms (not just modular ones)

Includes necessary docker change to inform chassisd if it is running on a modular platform. 