### PR TITLE
[ntp] Fix ntp.conf template to allow setting of source port in CONFIG_DB

### DIFF
--- a/files/image_config/ntp/ntp.conf.j2
+++ b/files/image_config/ntp/ntp.conf.j2
@@ -41,13 +41,15 @@ interface ignore wildcard
 # if the source interface is configured but no ip on that interface, then listen on another
 # interface based on existing logic
 {%- macro check_ip_on_interface(interface_name, table_name) %}
+    {%- set ns = namespace(valid_intf = 'false') %}
     {%- if table_name %}
         {%- for (name, source_prefix) in table_name|pfx_filter %}
             {%- if source_prefix and name == interface_name %}
-true
+                {%- set ns.valid_intf = 'true' %}
             {%- endif %}
         {%- endfor %}
     {%- endif %}
+{{ ns.valid_intf }}
 {%- endmacro %}
 
 {% set ns = namespace(source_intf = "") %}


### PR DESCRIPTION
#### Why I did it
Currently, there is a bug in the ntp.conf jinja2 template where it will ignore the `src_intf` directive in CONFIG_DB if there are multiple IP addresses associated with an interface. This code change fixes that bug and allows the template to select the correct source interface for NTP. 

#### How I did it
I did this by modifying the macro in `ntp.conf.j2` which determines if there is an ip address associated with an interface to set a state variable when it detects a valid interface entry in CONFIG_DB instead of outputting "true" directly (which could result in multiple "trues" outputted for interfaces with multiple valid IP addresses). 

#### How to verify it

1. Add two ipv4 addresses to an interface in SONiC

2. Add the following configuration to `config_db.json` 

```
{
"NTP": {
    "global": {
        "src_intf": "Ethernet1"
        }
    }
}
```
Replace `Ethernet1` with the interface name of the one you assigned the IP addresses to.

3. Run `sudo config reload -y`

4. Open `/etc/ntp.conf` and verify that the following line exists

```
...
interface listen Ethernet1
...
```
The interface specified should be the one set in the previous steps. 

#### Description for the changelog
[ntp] Fix ntp.conf template to allow setting of source port in CONFIG_DB


#### A picture of a cute animal (not mandatory but encouraged)
![Light-Gray-German-Angora-Rabbit_Hidden-Springs-Farm_Shutterstock-e1612565280404](https://user-images.githubusercontent.com/5898707/117239042-06a87800-adfc-11eb-9210-1c8fdde372e4.jpg)

