### PR TITLE
[sonic-py-common] Add platform and chassis info methods to device_info

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -7,6 +7,8 @@ import subprocess
 import yaml
 from natsort import natsorted
 
+from . import multi_asic
+
 # TODO: Replace with swsscommon
 from swsssdk import ConfigDBConnector, SonicDBConfig, SonicV2Connector
 
@@ -31,6 +33,52 @@ NAMESPACE_PATH_GLOB = "/run/netns/*"
 ASIC_CONF_FILENAME = "asic.conf"
 FRONTEND_ASIC_SUB_ROLE = "FrontEnd"
 BACKEND_ASIC_SUB_ROLE = "BackEnd"
+
+# Chassis STATE_DB keys
+CHASSIS_INFO_TABLE = 'CHASSIS_INFO|chassis {}'
+CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
+CHASSIS_INFO_SERIAL_FIELD = 'serial'
+CHASSIS_INFO_MODEL_FIELD = 'model'
+CHASSIS_INFO_REV_FIELD = 'revision'
+
+# Get hardware information
+def get_platform_info():
+    """
+    This function is used to get the HW info helper function
+    """
+
+    hw_info_dict = {}
+
+    version_info = device_info.get_sonic_version_info()
+
+    hw_info_dict['platform'] = device_info.get_platform()
+    hw_info_dict['hwsku'] = device_info.get_hwsku()
+    hw_info_dict['asic_type'] = version_info['asic_type']
+    hw_info_dict['asic_count'] = multi_asic.get_num_asics()
+
+    return hw_info_dict
+
+
+def get_chassis_info():
+    """
+    This function is used to get the Chassis serial / model / rev number
+    """
+
+    chassis_info_dict = {}
+
+    try:
+        # Init statedb connection
+        db = swsscommon.SonicV2Connector()
+        db.connect(db.STATE_DB)
+        table = CHASSIS_INFO_TABLE.format(1)
+
+        chassis_info_dict['serial'] = db.get(db.STATE_DB, table, CHASSIS_INFO_SERIAL_FIELD)
+        chassis_info_dict['model'] = db.get(db.STATE_DB, table, CHASSIS_INFO_MODEL_FIELD)
+        chassis_info_dict['revision'] = db.get(db.STATE_DB, table, CHASSIS_INFO_REV_FIELD)
+    except:
+        pass
+
+    return chassis_info_dict
 
 
 def get_localhost_info(field):

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -7,8 +7,6 @@ import subprocess
 import yaml
 from natsort import natsorted
 
-from . import multi_asic
-
 # TODO: Replace with swsscommon
 from swsssdk import ConfigDBConnector, SonicDBConfig, SonicV2Connector
 
@@ -46,15 +44,16 @@ def get_platform_info():
     """
     This function is used to get the HW info helper function
     """
+    from .multi_asic import get_num_asics
 
     hw_info_dict = {}
 
-    version_info = device_info.get_sonic_version_info()
+    version_info = get_sonic_version_info()
 
-    hw_info_dict['platform'] = device_info.get_platform()
-    hw_info_dict['hwsku'] = device_info.get_hwsku()
+    hw_info_dict['platform'] = get_platform()
+    hw_info_dict['hwsku'] = get_hwsku()
     hw_info_dict['asic_type'] = version_info['asic_type']
-    hw_info_dict['asic_count'] = multi_asic.get_num_asics()
+    hw_info_dict['asic_count'] = get_num_asics()
 
     return hw_info_dict
 

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -67,7 +67,7 @@ def get_chassis_info():
 
     try:
         # Init statedb connection
-        db = swsscommon.SonicV2Connector()
+        db = SonicV2Connector()
         db.connect(db.STATE_DB)
         table = CHASSIS_INFO_TABLE.format(1)
 

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -11,6 +11,7 @@ else:
 
 from sonic_py_common import device_info
 
+from . import mock_swsssdk
 
 # TODO: Remove this if/else block once we no longer support Python 2
 if sys.version_info.major == 3:
@@ -49,7 +50,6 @@ EXPECTED_GET_MACHINE_INFO_RESULT = {
     'onie_kernel_version': '4.10.11'
 }
 
-
 class TestDeviceInfo(object):
     @classmethod
     def setup_class(cls):
@@ -69,6 +69,14 @@ class TestDeviceInfo(object):
             get_machine_info_mocked.return_value = EXPECTED_GET_MACHINE_INFO_RESULT
             result = device_info.get_platform()
             assert result == "x86_64-mlnx_msn2700-r0"
+
+    def test_get_chassis_info(self):
+        with mock.patch("device_info.swsssdk", new=mock_swsssdk):
+            result = device_info.get_chassis_info()
+            truth = {"serial": self.TEST_SERIAL, 
+                     "model": self.TEST_MODEL, 
+                     "revision": self.TEST_REV}
+            assert result == truth
 
     @classmethod
     def teardown_class(cls):

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -11,7 +11,7 @@ else:
 
 from sonic_py_common import device_info
 
-from . import mock_swsssdk
+from .mock_swsssdk import SonicV2Connector
 
 # TODO: Remove this if/else block once we no longer support Python 2
 if sys.version_info.major == 3:
@@ -71,11 +71,11 @@ class TestDeviceInfo(object):
             assert result == "x86_64-mlnx_msn2700-r0"
 
     def test_get_chassis_info(self):
-        with mock.patch("device_info.swsssdk", new=mock_swsssdk):
+        with mock.patch("sonic_py_common.device_info.SonicV2Connector", new=SonicV2Connector):
             result = device_info.get_chassis_info()
-            truth = {"serial": self.TEST_SERIAL, 
-                     "model": self.TEST_MODEL, 
-                     "revision": self.TEST_REV}
+            truth = {"serial": SonicV2Connector.TEST_SERIAL, 
+                     "model": SonicV2Connector.TEST_MODEL, 
+                     "revision": SonicV2Connector.TEST_REV}
             assert result == truth
 
     @classmethod

--- a/src/sonic-py-common/tests/mock_swsssdk.py
+++ b/src/sonic-py-common/tests/mock_swsssdk.py
@@ -1,0 +1,13 @@
+class SonicV2Connector:
+
+    def __init__(self):
+        self.STATE_DB = 'STATE_DB'
+        self.data = {"serial": self.TEST_SERIAL, 
+                     "model": self.TEST_MODEL, 
+                     "revision": self.TEST_REV}
+    
+    def connect(self, db):
+        pass
+
+    def get(self, db, table, field):
+        self.data.get(field, "N/A")

--- a/src/sonic-py-common/tests/mock_swsssdk.py
+++ b/src/sonic-py-common/tests/mock_swsssdk.py
@@ -1,4 +1,7 @@
 class SonicV2Connector:
+    TEST_SERIAL = "MT1822K07815"
+    TEST_MODEL = "MSN2700-CS2FO"
+    TEST_REV = "A1"
 
     def __init__(self):
         self.STATE_DB = 'STATE_DB'
@@ -10,4 +13,4 @@ class SonicV2Connector:
         pass
 
     def get(self, db, table, field):
-        self.data.get(field, "N/A")
+        return self.data.get(field, "N/A")


### PR DESCRIPTION
#### Why I did it
These methods were added to make some convenient platform and chassis information methods accessible through sonic-py-common. These methods were refactored from sonic-utilities and are used in the `show platform summary` and `show version` commands. 

#### How I did it
There are two methods, one is `get_platform_info()` which simply calls local methods to collect useful platform information into a dictionary format, this came directly from sonic-utilities.

The other method is `get_chassis_info()` which retrieves the chassis model, serial number, and hardware revision from the STATE_DB directly. This is also utilized by sonic-utilities which is added by https://github.com/robocoder99/sonic-utilities/pull/3

#### How to verify it
Open a python3 interpreter and enter the following lines
```
Python 3.7.3 (default, Jan 22 2021, 20:04:44)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from sonic_py_common import device_info
>>> device_info.get_platform_info()
{'platform': 'x86_64-mlnx_msn2700-r0', 'hwsku': 'ACS-MSN2700', 'asic_type': 'mellanox', 'asic_count': 1}
>>> device_info.get_chassis_info()
{'model':'MSN2700-CS2FO', 'serial':'MT1623X09522', 'revision': 'A1'}
```

For different platforms these values will be different, simply check if they are successfully populated. If https://github.com/robocoder99/sonic-platform-daemons/pull/3 has not been merged then `get_chassis_info()` is expected to return an empty dictionary. 

#### Description for the changelog
[sonic-py-common] Add platform and chassis info methods to device_info


#### A picture of a cute animal (not mandatory but encouraged)
![Highland-Cow-Lavena-and-calf-Star](https://user-images.githubusercontent.com/5898707/117913100-bc694000-b2ae-11eb-855e-7fad035e7d80.jpg)

